### PR TITLE
Switch the default theme to the ext accessibility theme

### DIFF
--- a/templates/geonode/ext_header.html
+++ b/templates/geonode/ext_header.html
@@ -1,5 +1,8 @@
 {% load mapstory_tags %}
 <link rel="stylesheet" type="text/css" href="{% geonode_static "externals/ext/resources/css/ext-all.css" %}" />
+
+<link rel="stylesheet" type="text/css" href="{% geonode_static "externals/ext/resources/css/xtheme-access.css"%}"/>
+
 <script type="text/javascript" src="{% geonode_static "externals/ext/adapter/ext/ext-base.js" %}"></script>
 <script type="text/javascript" src="{% geonode_static "externals/ext/ext-all.js" %}"></script>
 

--- a/templates/maps/view.html
+++ b/templates/maps/view.html
@@ -8,9 +8,11 @@
 {% include "geonode/ext_header.html" %}
 {% include "geonode/app_header.html" %}
 {% include "geonode/geo_header.html" %}
+
 <link rel="stylesheet" type="text/css" href="{% geonode_static "theme/ux/colorpicker/color-picker.ux.css" %}" />
 <style type="text/css">
     #templates { display: none; }
+    body {color: #FCFCFC !important;}
 </style>
 
 <script src="{% geonode_static "script/PrintPreview.js" %}"></script>


### PR DESCRIPTION
This commit switches the default theme for ext.js. It also adds a
small hack that overrides the body font color to work with the new
theme. This hack is because I was unable to change the order of the
css files.

Address #454 
