### PR TITLE
Initial add of django-announcements

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -233,6 +233,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.messages',
     'django_extensions',
+    'announcements',
     'hitcount',
     'account',
     'kaleo',

--- a/templates/page_layout.html
+++ b/templates/page_layout.html
@@ -4,6 +4,7 @@
 {% load i18n %}
 {% load mapstory_tags %}
 {% load cache %}
+{% load announcements_tags %}
 
 {% block style_base %}
     <link href="{% static "theme/bootstrap_custom.css" %}" rel="stylesheet" />
@@ -171,6 +172,24 @@
                     </div>
                 </div>
             {% endblock %}
+    {% announcements as announcements_list %}
+    {% if announcements_list %}
+        <div class="announcements">
+            {% for announcement in announcements_list %}
+                <div class="alert announcement" id="ann-{{ announcement.id }}">
+                    {% if announcement.dismiss_url %}
+                        <form id="dismiss_form-ann-{{ announcement.id }}" action="{{ announcement.dismiss_url }}" method="POST">
+                        {% csrf_token %}
+                        <button type="button" class="close" data-dismiss="alert" onclick="dismiss_ann('ann-{{announcement.id}}');">&times;</button>
+                        </form>
+                    {% endif %}
+                    <!--strong><a href = '{% url announcements_detail announcement.id %}'>{{ announcement.title }}</strong></a><br /-->
+                    <strong>{{ announcement.title }}</strong><br />
+                    {{ announcement.content }}
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
             {% comment %}
             {% block ads %}
                 <div class="row">
@@ -219,6 +238,20 @@
     </div><!-- /#footer -->
 {% endblock %}
 
-{% block extra_body_base %}
+ onclick="{% block extra_body_base %}
+<script type="text/javascript">
+    function dismiss_ann(annid) {
+        var frm = $('#dismiss_form-' + annid);
+            $.ajax({
+                type: frm.attr('method'),
+                url: frm.attr('action'),
+                data: frm.serialize(),
+                success: function (data) {
+                }
+            });
+            $('#' + annid).hide();
+            return false;
+    }
+</script>
 {% block extra_body %}{% endblock %}
 {% endblock %}

--- a/urls.py
+++ b/urls.py
@@ -107,6 +107,8 @@ urlpatterns += patterns('mapstory.views',
 
     url(r'^ajax/hitcount/$', update_hit_count_ajax, name='hitcount_update_ajax'),
 
+    url(r"^announcements/", include("announcements.urls")),
+
     # for now, direct-to-template but should be in database
     url(r"^mapstory/thoughts/jonathan-marino", direct_to_template, {"template": "mapstory/thoughts.html",
         "extra_context" : {'html':'mapstory/thoughts/jm.html'}}, name="thoughts-jm"),


### PR DESCRIPTION
Initial add of django-announcements. Not sure where to put the new requirements. A couple of things to note. First, the announcements are displayed at the _bottom_ of the page, almost certainly not where they belong. Someone with more design sense than me is going to have to put them somewhere better. Second, we should enable the user to click on the announcement title to go to a page that has the full announcement. I tried to do this by adding the announcement templates, but getting an error in the mapstory template tags. @ischneider we need to look at this.

Also, the javascript I included can probably use a bit of improvement. My jquery is a little rusty. It works, but can be improved.
