### PR TITLE
Fix the default names for default WMS layers in the map composer

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -190,7 +190,7 @@ MAP_BASELAYERS = [{
     "visibility": False,
     "fixed": True,
     "args":[
-      "bluemarble",
+      "Satellite Imagery",
       "http://maps.opengeo.org/geowebcache/service/wms",
       {
         "layers":["bluemarble"],
@@ -207,7 +207,7 @@ MAP_BASELAYERS = [{
     "visibility": False,
     "fixed": True,
     "args":[
-      "Wayne",
+      "Naked Earth",
       "http://maps.opengeo.org/geowebcache/service/wms",
       {
         "layers":["Wayne"],


### PR DESCRIPTION
This fixes the default name for new maps. Does not account for already existing maps. Address #479 
