### PR TITLE
Add Flag Functionality - Issue 470

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -235,6 +235,7 @@ INSTALLED_APPS = (
     'django_extensions',
     'announcements',
     'flatblocks',
+    'flag',
     'hitcount',
     'account',
     'kaleo',

--- a/templates/maps/layer.html
+++ b/templates/maps/layer.html
@@ -3,6 +3,7 @@
 {% load geonode_auth %}
 {% load mapstory_tags %}
 {% load dialogos_tags %}
+{% load flag_tags %}
 {% load agon_ratings_tags %}
 {% load staticfiles %}
 
@@ -204,7 +205,8 @@
                             <div class="fb-like" data-href="http://{{ request.get_host }}{{ request.get_full_path }}" data-send="false" data-width="50" data-layout="button_count" data-show-faces="false"></div>
                         </div>
                         <div class="tab-pane" id="actions4">
-                            Flag not implemented yet
+                            TODO: Say Something here about what flagging is all about
+                            {% flag layer "owner" %}
                         </div>
                         <div class="tab-pane" id="actions5">
                             {% if user.is_authenticated %}

--- a/templates/maps/layer.html
+++ b/templates/maps/layer.html
@@ -3,7 +3,7 @@
 {% load geonode_auth %}
 {% load mapstory_tags %}
 {% load dialogos_tags %}
-{% load flag_tags %}
+{% load flagtags %}
 {% load agon_ratings_tags %}
 {% load staticfiles %}
 
@@ -205,7 +205,7 @@
                             <div class="fb-like" data-href="http://{{ request.get_host }}{{ request.get_full_path }}" data-send="false" data-width="50" data-layout="button_count" data-show-faces="false"></div>
                         </div>
                         <div class="tab-pane" id="actions4">
-                            TODO: Say Something here about what flagging is all about
+                            {% comment %} TODO: Say Something here about what flagging is all about {% endcomment %}
                             {% flag layer "owner" %}
                         </div>
                         <div class="tab-pane" id="actions5">

--- a/templates/maps/mapinfo.html
+++ b/templates/maps/mapinfo.html
@@ -4,6 +4,7 @@
 {% load geonode_auth %}
 {% load mapstory_tags %}
 {% load dialogos_tags %}
+{% load flagtags %}
 {% load agon_ratings_tags %}
 
 {% block title %}{{map.title}}{% endblock %}
@@ -161,7 +162,8 @@ var thumbURL = "{% url geonode.maps.views.map_controller map.id %}?thumbnail";
                             <textarea><iframe style="border: none;" height="400" width="600" src="http://{{ request.get_host }}{% url geonode.maps.views.embed map.id %}"></iframe></textarea>
                         </div>
                         <div class="tab-pane" id="actions4">
-                            Flag not implemented yet
+                            {% comment %} TODO: Say Something here about what flagging is all about {% endcomment %}
+                            {% flag map "owner" %}
                         </div>
                         <div class="tab-pane" id="actions5">
                             {% if user.is_authenticated %}

--- a/urls.py
+++ b/urls.py
@@ -109,6 +109,7 @@ urlpatterns += patterns('mapstory.views',
     url(r'^ajax/hitcount/$', update_hit_count_ajax, name='hitcount_update_ajax'),
 
     url(r"^announcements/", include("announcements.urls")),
+    url(r"^flag/", include("flag.urls")),
 
     # for now, direct-to-template but should be in database
     url(r"^mapstory/thoughts/jonathan-marino", direct_to_template, {"template": "mapstory/thoughts.html",


### PR DESCRIPTION
Adds Flag functionality to Layer and Map pages. 

Requires geonode pull request to add django-flag to shared/requirements.txt  https://github.com/opengeo/geonode/pull/13

Also, required monkey-patching django-flag a bit in order to use the one from pypi. It looks like using the one from the github repo has fixed some of the issues I encountered. Not sure how we handle this in mapstory, but in mainline geonode we always try to use the pypi version whenever possible.
