### PR TITLE
Move the access shim css into its own file

### DIFF
--- a/media/theme/access-theme-shim.css
+++ b/media/theme/access-theme-shim.css
@@ -1,0 +1,33 @@
+/** 
+This is a shim to make the ext access theme work with the current
+ext.js theme
+**/
+
+.xtb-text {
+    color: #fff;
+}
+.x-combo-list {
+    color: #fff;
+}
+
+.x-tab-panel-body {
+    background: #1f2730;
+}
+.x-grid3-row-over {
+    background: #000;
+}
+.gxp-export-section {
+    color: #fff;
+}
+
+.x-tip-body {
+    color: #fff !important;
+}
+
+.x-panel-body label {
+    color: #fff;
+}
+
+.timeline-event-label {
+    color: #000;
+}

--- a/media/theme/site.css
+++ b/media/theme/site.css
@@ -2161,33 +2161,3 @@ h2.icn-storylayer span, h2.icn-mapstory span {
     width: 80%;
     resize: both;
 }
-
-
-.xtb-text {
-    color: #fff;
-}
-.x-combo-list {
-    color: #fff;
-}
-
-.x-tab-panel-body {
-    background: #1f2730;
-}
-.x-grid3-row-over {
-    background: #000;
-}
-.gxp-export-section {
-    color: #fff;
-}
-
-.x-tip-body {
-    color: #fff !important;
-}
-
-.x-panel-body label {
-    color: #fff;
-}
-
-.timeline-event-label {
-    color: #000;
-}

--- a/templates/maps/view.html
+++ b/templates/maps/view.html
@@ -1,4 +1,5 @@
 {% extends "fullscreen.html" %}
+{% load staticfiles %}
 {% load i18n %}
 {% load mapstory_tags %}
 
@@ -8,6 +9,7 @@
 {% include "geonode/ext_header.html" %}
 {% include "geonode/app_header.html" %}
 {% include "geonode/geo_header.html" %}
+<link rel="stylesheet" type="text/css" href="{% static "theme/access-theme-shim.css"%}" />
 <link rel="stylesheet" type="text/css" href="{% geonode_static "theme/ux/colorpicker/color-picker.ux.css" %}" />
 <style type="text/css">
     #templates { display: none; }


### PR DESCRIPTION
Because we only include the access theme in some pages, we need to
move the shim into its own file. This commit also includes the shim in
the only page that we use the access them on.
