### PR TITLE
Add oEmbed Support

### DIFF
--- a/oembed_providers.py
+++ b/oembed_providers.py
@@ -1,0 +1,39 @@
+import oembed
+from oembed.providers import BaseProvider
+from oembed.resources import OEmbedResource
+from oembed.utils import size_to_nearest, scale
+from django.conf import settings
+import re
+from urlparse import urlparse
+from django.shortcuts import get_object_or_404
+from geonode.maps.models import Map
+
+class MapStoryProvider(BaseProvider):
+    regex = settings.SITEURL.replace('/', '\/') + 'maps\/\d+' 
+    print regex
+    provides = True 
+    resource_type = 'rich'
+    
+    def request_resource(self, url, **kwargs):
+        pattern = settings.SITEURL.replace('/', '\/') + 'maps\/\d+'
+        result = re.match(pattern, url)
+        if result is None:
+            return HttpResponse(("Invalid oEmbed URL"), status=400, mimetype="text/plain")
+        else:
+            map_id = int(urlparse(url).path.split('/')[2])
+            map_obj = get_object_or_404(Map, id=map_id)
+            #if not request.user.has_perm('maps.view_map', obj=map_obj):
+            #    return HttpResponse(("Not Permitted"), status=401, mimetype="text/plain")
+        maxwidth = kwargs.get('maxwidth', None)
+        maxheight = kwargs.get('maxheight', None)
+        
+        # prepare the dictionary of data to be returned as an oembed resource
+        data = {
+            'type': 'rich', 'provider_name': 'MapStory', 'version': '1.0',
+            'width': maxwidth, 'height': maxheight, 'title': map_obj.title, 'author_name': map_obj.owner.username,
+            'author_url': settings.SITEURL[:-1] + map_obj.owner.get_absolute_url() 
+        }
+        embed_url = settings.SITEURL[:-1] + map_obj.get_absolute_url() + '/embed'
+        data['html'] = '<iframe style="border: none;" height="%s" width="%s" src="%s"></iframe>' % (maxheight, maxwidth, embed_url) 
+        
+        return OEmbedResource.create(data)

--- a/settings.py
+++ b/settings.py
@@ -255,6 +255,7 @@ INSTALLED_APPS = (
     'mapstory.watchdog',
     'actstream',
     'mailer',
+    'oembed',
 )
 
 def get_user_url(u):

--- a/urls.py
+++ b/urls.py
@@ -118,8 +118,6 @@ urlpatterns += patterns('mapstory.views',
     url(r"^announcements/", include("announcements.urls")),
     url(r"^flag/", include("flag.urls")),
 
-    #url(r'^oembed/$', 'oembed', name='oembed'),
-
     # for now, direct-to-template but should be in database
     url(r"^mapstory/thoughts/jonathan-marino/$", direct_to_template, {"template": "mapstory/thoughts.html",
         "extra_context" : {'html':'mapstory/thoughts/jm.html'}}, name="thoughts-jm"),

--- a/urls.py
+++ b/urls.py
@@ -18,6 +18,11 @@ from mapstory import social_signals
 from django.contrib import admin
 admin.autodiscover()
 
+import oembed
+oembed.autodiscover()
+from oembed_providers import MapStoryProvider
+oembed.site.register(MapStoryProvider)
+
 js_info_dict = {
     'domain': 'djangojs',
     'packages': ('geonode',)
@@ -72,6 +77,7 @@ urlpatterns += patterns('mapstory.views',
     (r'', include('geonode.simplesearch.urls')), # put this first to ensure search urls priority
     (r'', include('geonode.urls')),
     url(r"^invites/", include("kaleo.urls")),
+    url(r'^oembed/', include("oembed.urls")),
     
     (r'^data/create_annotations_layer/(?P<mapid>\d+)$','create_annotations_layer'),
     url(r'^mapstory/donate/$',direct_to_template, {"template":"mapstory/donate.html"},name='donate'),
@@ -112,7 +118,7 @@ urlpatterns += patterns('mapstory.views',
     url(r"^announcements/", include("announcements.urls")),
     url(r"^flag/", include("flag.urls")),
 
-    url(r'^oembed/$', 'oembed', name='oembed'),
+    #url(r'^oembed/$', 'oembed', name='oembed'),
 
     # for now, direct-to-template but should be in database
     url(r"^mapstory/thoughts/jonathan-marino/$", direct_to_template, {"template": "mapstory/thoughts.html",

--- a/urls.py
+++ b/urls.py
@@ -112,6 +112,7 @@ urlpatterns += patterns('mapstory.views',
     url(r"^announcements/", include("announcements.urls")),
     url(r"^flag/", include("flag.urls")),
 
+    url(r'^oembed/$', 'oembed', name='oembed'),
 
     # for now, direct-to-template but should be in database
     url(r"^mapstory/thoughts/jonathan-marino/$", direct_to_template, {"template": "mapstory/thoughts.html",

--- a/views.py
+++ b/views.py
@@ -31,9 +31,11 @@ from django.views.decorators.http import require_POST
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
+from django.http import HttpResponseBadRequest
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.template import loader
+from django.template.loader import render_to_string
 from django.contrib.contenttypes.models import ContentType
 from django.views.decorators.cache import cache_page
 
@@ -42,6 +44,10 @@ from datetime import datetime
 import math
 import os
 import random
+import json
+import urllib
+from urlparse import urlparse
+import re
 
 def alerts(req): 
     return render_to_response('mapstory/alerts.html', RequestContext(req))
@@ -557,5 +563,43 @@ def _remove_annotation_layer(sender, instance, **kw):
         Layer.objects.get(name='_map_%s_annotations' % instance.id)
     except Layer.DoesNotExist:
         pass
+
+def oembed(request):
+    url = request.GET.get('url')
+    if url is None:
+        return HttpResponseBadRequest()
+    else:
+        url = urllib.unquote_plus(url)
+    pattern = settings.SITEURL.replace('/', '\/') + 'maps\/\d+'
+    result = re.match(pattern, url)
+    if result is None:
+        return HttpResponse(_("Invalid oEmbed URL"), status=400, mimetype="text/plain")
+    else:
+        map_id = int(urlparse(url).path.split('/')[2])
+        map_obj = get_object_or_404(Map, id=map_id)
+        if not request.user.has_perm('maps.view_map', obj=map_obj):
+            return HttpResponse(_("Not Permitted"), status=401, mimetype="text/plain")
+    format = request.GET.get('format', 'json') #Actually ignored for now
+    maxwidth = request.GET.get('maxwidth', 600)
+    maxheight = request.GET.get('maxheight', 400)
+    embed_url = settings.SITEURL[:-1] + map_obj.get_absolute_url() + '/embed'
+    html = "<iframe style='border: none;' height='%d' width='%d' src='%s'></iframe>" % (maxheight, maxwidth, embed_url) 
+    response = {}
+    response['type'] = "rich"
+    response['version'] = 1.0
+    response['title'] = map_obj.title 
+    response['author_name'] = map_obj.owner.username
+    response['author_url'] = settings.SITEURL[:-1] + map_obj.owner.get_absolute_url()
+    response['provider_name'] = "MapStory"
+    response['provider_url'] = settings.SITEURL
+    #response['cache_age'] = ""
+    #response['thumbnail_url'] = ""
+    #response['thumbnail_width'] = ""
+    #response['thumbnail_height'] = ""
+    response['html'] = html
+    response['width'] = maxwidth 
+    response['height'] = maxheight
+
+    return HttpResponse(json.dumps(response), mimetype="application/json")
 
 signals.pre_delete.connect(_remove_annotation_layer, sender=Map)


### PR DESCRIPTION
This PR adds oEmbed support to mapstory enabling it to be both a consumer and provider of oEmbed functionality (we only care about being a provider now, but consumer support is there should we need it).

This relies on this library https://github.com/worldcompany/djangoembed/ which very clearly says it is unmaintained, yet the alternate library it mentions does not include oEmbed provider support. I tried to do a manual implementation of oEmbed provider and could not get it to work with Wordpress, so gave up and used this library.

I've tested this with  Wordpress and it works if you add the following lines as a plugin to your wordpress install. The best path forward here is to make an actual mapstory plugin for wordpress that is easy to install. That should be trivial, but requires a bit of discussion on how its to be distributed etc. Beyond that, wordpress would have to whitelist our site in order to make it work directly with hosted sites on wordpress.com. We can also look into embed.ly as an option.

function wpb_oembed_mapstory(){
wp_oembed_add_provider( 'http://mapstory.dev.opengeo.org/maps/*', 'http://mapstory.dev.opengeo.org/oembed/json' );
}
add_action('init','wpb_oembed_mapstory');

One other thing to note is that the maps embed page is not currently setup properly. It displays the entire page headers and all. We need to make this file https://github.com/opengeo/mapstory/blob/master/templates/maps/embed.html look more like this one https://github.com/opengeo/geonode/blob/mapstory/src/GeoNodePy/geonode/templates/maps/embed.html hoping that @ischneider can help me with that as I dont have my head fully wrapped around the way the viewer works.

@cholmes I had this stood up on dev, but I believe it was re-deployed. Once this PR is merged, we can test again.
