### PR TITLE
Force ribbon/carousel images to be height 200

### DIFF
--- a/models.py
+++ b/models.py
@@ -210,14 +210,31 @@ class Link(models.Model):
                 return match.group(1)
 
     def render(self, width=None, height=None):
-        ctx = dict(href=self.href, name=self.name, width=width or 256, height=height or 128)
+        if width and height:
+            xwidth = "width='%s'" % width
+            xheight = "height='%s'" % height 
+            style = "style='height:%spx !important; width:%spx !important;'" % (width, height)
+        elif height and width == None:
+            xwidth = ""
+            xheight = "height='%s'" % height 
+            style = "style='height:%spx !important;'" % height
+        elif width and height == None:
+            xwidth = "width='%s'" % width 
+            xheight = ""
+            style = "style='width:%spx !important;'" % width
+        else:
+            xwidth = "width='256'"
+            xheight = "height='128'"
+            style = "style='width:256px !important;height:128px !important;'"
+        print style
+        ctx = dict(href=self.href, name=self.name, width=xwidth, height=xheight, style=style)
         if self.is_image():
-            return '<img width="%(width)s" src="%(href)s" title="%(name)s"></img>' % ctx
+            return '<img %(style)s %(width)s %(height)s src="%(href)s" title="%(name)s"></img>' % ctx
         video = self.get_youtube_video()
         if video:
             ctx['video'] = video
             return ('<iframe class="youtube-player" type="text/html"'
-                    ' width="%(width)s" height="%(height)s" frameborder="0"'
+                    ' %(width)s %(height)s frameborder="0"'
                     ' src="http://www.youtube.com/embed/%(video)s">'
                     '</iframe>') % ctx
         return '<a target="_" href="%(href)s">%(name)s</a>' % ctx

--- a/templates/mapstory/orgs/org_page.html
+++ b/templates/mapstory/orgs/org_page.html
@@ -110,7 +110,7 @@
         <div class="arrow arrow-right" style="right:15px">&#8827;</div>
         {% if org.ribbon_links.count %}
             {% for l in org.ribbon_links.all %}
-            <li class="tile" id="ribbon-link-{{ l.pk }}">{% render_link l %}</li>
+            <li class="tile" id="ribbon-link-{{ l.pk }}">{% render_link l height=200 %}</li>
             {% endfor %}
         {% endif %}
     </ul>


### PR DESCRIPTION
This alters the Link.render method to let it take either a height or a width (or both or none) and only specify that in the img tag and let the browser resize. Then uses this in the ribbon in the Org page.

There is a well known problem with bootstrap overriding the specified heights in an img tag 
https://www.google.com/search?q=override+twitter+height+auto+bootstrap ... so I resorted to some ugly inline styles to force this. @ischneider can you take a look at this and suggest improvements perhaps. Wasted way too long on this and now that it works Im walking away for now.

Closes #597
