### PR TITLE
Initial work on adding twitter card meta tags to the layer and map pages

### DIFF
--- a/templates/_twitter_card_meta.html
+++ b/templates/_twitter_card_meta.html
@@ -1,0 +1,7 @@
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@mapstory">
+{# todo: add creator tag if twitter username is known #}
+<meta name="twitter:url" content="{{ url }}">
+<meta name="twitter:title" content="{{ title }}">
+<meta name="twitter:description" content="{{ content }}">
+<meta name="twitter:image" content="{{ image }}">

--- a/templates/maps/layer.html
+++ b/templates/maps/layer.html
@@ -11,6 +11,7 @@
 
 {% block extra_head %}
 {% open_graph_meta layer %}
+{% twitter_card_meta layer %}
 {% include "maps/_sharethis_scripts.html" %}
 <link rel="stylesheet" type="text/css" href="/static/theme/comments.css" media="screen" />
 {% include "geonode/app_header.html" %}

--- a/templates/maps/mapinfo.html
+++ b/templates/maps/mapinfo.html
@@ -12,6 +12,7 @@
 
 {% block extra_head %}
 {% open_graph_meta map %}
+{% twitter_card_meta layer %}
 {% include "maps/_sharethis_scripts.html" %}
 <link rel="stylesheet" type="text/css" href="{% static "theme/comments.css" %}" media="screen" />
 <style type="text/css">

--- a/templates/maps/mapinfo.html
+++ b/templates/maps/mapinfo.html
@@ -12,7 +12,7 @@
 
 {% block extra_head %}
 {% open_graph_meta map %}
-{% twitter_card_meta layer %}
+{% twitter_card_meta map %}
 {% include "maps/_sharethis_scripts.html" %}
 <link rel="stylesheet" type="text/css" href="{% static "theme/comments.css" %}" media="screen" />
 <style type="text/css">

--- a/templatetags/mapstory_tags.py
+++ b/templatetags/mapstory_tags.py
@@ -398,9 +398,19 @@ def open_graph_meta(obj):
     return loader.render_to_string('_open_graph_meta.html', {
         'title' : obj.title,
         'type' : typename,
-        'url' : obj.get_absolute_url(),
+        'url' : absolutize(obj.get_absolute_url()),
         'image' : obj.get_thumbnail_url()
     })
+
+@register.simple_tag
+def twitter_card_meta(obj):
+    return loader.render_to_string('_twitter_card_meta.html', {
+        'title' : obj.title,
+        'content' : obj.abstract,
+        'url' : absolutize(obj.get_absolute_url()),
+        'image' : obj.get_thumbnail_url()
+    })
+    
 
 # @todo - make geonode location play better
 if settings.GEONODE_CLIENT_LOCATION.startswith("http"):


### PR DESCRIPTION
refs #500

This adds the initial summary card meta tags to the layer and map page. They were tested on dev, but the twitter card preview tool seems to be broken (not even displaying nytimes links that should work). I will circle back and test this. 

Next steps after making sure this works with the preview tool are to ask for the site to be whitelisted and then make some experiments with the player in an iframe. Not sure if we need to do the player, a summary and link may be fine.
